### PR TITLE
Update Swagger assets to the latest version

### DIFF
--- a/src/Bundle/Resources/views/index.html.php
+++ b/src/Bundle/Resources/views/index.html.php
@@ -65,8 +65,8 @@
 
 <div id="swagger-ui"></div>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.19.4/swagger-ui-bundle.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.19.4/swagger-ui-standalone-preset.js"> </script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.23.10/swagger-ui-bundle.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.23.10/swagger-ui-standalone-preset.js"> </script>
 <script>
     window.onload = function() {
         const ui = SwaggerUIBundle({


### PR DESCRIPTION
Don't know why, but with current version it doesn't work

![image](https://user-images.githubusercontent.com/191082/65032866-af1a7780-d94c-11e9-8d0c-e142b0ddbe2e.png)
