### PR TITLE
feature/add-php8-compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "~7.1",
+        "php": "~7.1 | >=8.0",
         "ext-json": "*",
         "symfony/config": ">=3.4",
         "symfony/console": ">=3.4",


### PR DESCRIPTION
- Add compatibility with PHP >= 8.0

I have tested it with a Symfony 5.4.0 project and PHP 8.1.1